### PR TITLE
スコアはパーセント表記から実数表記になったので100倍する

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -79,7 +79,7 @@ def post_scores_to_mackerel(mackerel_service: , api_key: , scores: )
   mackerel_client.post_service_metrics(mackerel_service, scores.map {|(url, score)|
     {
       name: "custom.pagespeed.#{as_metric_name(url)}",
-      value: score,
+      value: score * 100,
       time: now.to_i,
     }
   })


### PR DESCRIPTION
Mackerelではパーセント表示だったので0〜100で投稿していた．しかしAPIの仕様変更か0〜1の実数が返ってくるようになったため，Mackerelに投稿する箇所で100倍しておく